### PR TITLE
fix: Correct Dockerfile to resolve build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 # Stage 1: Build the frontend
 FROM node:18-alpine AS frontend
 WORKDIR /app/web
-COPY web/package.json web/package-lock.json ./
+COPY web/ ./
 RUN npm install
-COPY web ./
 RUN npm run build-prod
 
 # Stage 2: Build the server


### PR DESCRIPTION
This commit fixes the Dockerfile to resolve a build error related to the `COPY` command. The frontend build stage has been simplified to copy the entire `web` directory at once, which is a more robust approach.

This also includes the previous enhancements:

- **Configuration with Environment Variables:** The server can now be configured using environment variables, which is a best practice for containerized applications.
- **Issue Fix:** A potential issue in the request handling logic has been fixed to improve stability.
- **Dockerfile:** A multi-stage Dockerfile is added to build the frontend and backend, creating a minimal final image.
- **.dockerignore:** A .dockerignore file is added to optimize the Docker build process.